### PR TITLE
Scoring method fix

### DIFF
--- a/air_passengers_starting_kit.ipynb
+++ b/air_passengers_starting_kit.ipynb
@@ -1632,7 +1632,7 @@
     "\n",
     "reg = LinearRegression()\n",
     "\n",
-    "scores = cross_val_score(reg, X_train, y_train, cv=5, scoring='mean_squared_error')\n",
+    "scores = cross_val_score(reg, X_train, y_train, cv=5, scoring='neg_mean_squared_error')\n",
     "print(\"log RMSE: {:.4f} +/-{:.4f}\".format(\n",
     "    np.mean(np.sqrt(-scores)), np.std(np.sqrt(-scores))))"
    ]
@@ -1691,7 +1691,7 @@
     "max_features = 10\n",
     "reg = RandomForestRegressor(n_estimators=n_estimators, max_depth=max_depth, max_features=max_features)\n",
     "\n",
-    "scores = cross_val_score(reg, X_train, y_train, cv=5, scoring='mean_squared_error',n_jobs=3)\n",
+    "scores = cross_val_score(reg, X_train, y_train, cv=5, scoring='neg_mean_squared_error',n_jobs=3)\n",
     "print(\"log RMSE: {:.4f} +/-{:.4f}\".format(\n",
     "    np.mean(np.sqrt(-scores)), np.std(np.sqrt(-scores))))"
    ]


### PR DESCRIPTION
Dear maintainers of RAMP starting kits, this is a proposed fix to a deprecation warning into air_passengers_starting_kit.ipynb in this starting kit.

A DeprecationWarning is thrown on two occasions in air_passengers_starting_kit.ipynb due to the use of the deprecated mean_squared_error scoring method with the cross_val_scores function from scikit-learn. The use of neg_mean_squared_error scoring method is suggested instead.

Should you accept this pull request, you may wish to regenerate the file in jupyter.

Kind regards,

(Refers to DeprecationWarning: Scoring method mean_squared_error was renamed to neg_mean_squared_error in version 0.18 and will be removed in 0.20.)